### PR TITLE
chore: E3 errata (plugin cache drift) + bootstrap --sync-plugin

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,27 +7,75 @@ set -euo pipefail
 # This script handles: CLAUDE.md, rules, scripts, scheduler, claude-flow
 #
 # Usage:
-#   ./bootstrap.sh          Full sync (idempotent, safe to re-run)
-#   ./bootstrap.sh --check  Show what would change without applying
-#   ./bootstrap.sh --help   Show this help
+#   ./bootstrap.sh                Full sync (idempotent, safe to re-run)
+#   ./bootstrap.sh --check        Show what would change without applying
+#   ./bootstrap.sh --sync-plugin  Sync plugin cache with current system/
+#   ./bootstrap.sh --help         Show this help
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SYSTEM_DIR="$SCRIPT_DIR/system"
 TARGET_DIR="$HOME/.claude"
 CHECK_ONLY=false
 
+# --- Plugin cache sync (standalone operation) ---
+sync_plugin_cache() {
+    local system_dir="$1"
+    local cache_base="$HOME/.claude/plugins/cache/brana/brana"
+
+    # Find installed version directory
+    local cache_dir=""
+    for d in "$cache_base"/*/; do
+        [ -d "$d" ] && cache_dir="${d%/}" && break
+    done
+
+    if [ -z "$cache_dir" ]; then
+        echo "No installed brana plugin found in $cache_base"
+        echo "Install with: claude plugin install brana"
+        exit 1
+    fi
+
+    local version=$(basename "$cache_dir")
+    echo "=== Syncing plugin cache ==="
+    echo "Source:  $system_dir"
+    echo "Cache:   $cache_dir (v$version)"
+    echo ""
+
+    # Dry-run diff first
+    local diff_output
+    diff_output=$(diff -rq "$cache_dir" "$system_dir" 2>/dev/null | grep -v ".claude-plugin" || true)
+
+    if [ -z "$diff_output" ]; then
+        echo "Plugin cache is already up to date."
+        exit 0
+    fi
+
+    echo "Changes:"
+    echo "$diff_output" | while IFS= read -r line; do
+        echo "  $line"
+    done
+    echo ""
+
+    rsync -av --delete --exclude='.claude-plugin' "$system_dir/" "$cache_dir/" > /dev/null
+    echo "Plugin cache synced. Restart Claude Code to activate."
+}
+
 # Parse args
 case "${1:-}" in
     --check)  CHECK_ONLY=true ;;
+    --sync-plugin)
+        sync_plugin_cache "$SYSTEM_DIR"
+        exit 0
+        ;;
     --help|-h)
-        echo "Usage: ./bootstrap.sh [--check|--help]"
+        echo "Usage: ./bootstrap.sh [--check|--sync-plugin|--help]"
         echo ""
         echo "Deploy brana identity layer (CLAUDE.md, rules, scripts, scheduler, claude-flow)."
         echo "The brana plugin handles skills, agents, hooks, and commands."
         echo ""
         echo "Options:"
-        echo "  --check  Show what would change without applying"
-        echo "  --help   Show this help"
+        echo "  --check        Show what would change without applying"
+        echo "  --sync-plugin  Sync installed plugin cache with current system/"
+        echo "  --help         Show this help"
         echo ""
         echo "This script is idempotent — safe to run multiple times."
         exit 0

--- a/docs/architecture/features/plugin-packaging.md
+++ b/docs/architecture/features/plugin-packaging.md
@@ -268,3 +268,16 @@ CC v2.1.x does not dispatch PostToolUse or PostToolUseFailure events to plugin h
 Users upgrading from `deploy.sh` to the plugin have stale copies of skills, commands, and agents in `~/.claude/`. These cause duplicate skill registration — skills appear both unprefixed (from `~/.claude/skills/`) and with `brana:` prefix (from the plugin). Silent, confusing failure mode.
 
 **Fix:** `bootstrap.sh` Step 1b removes `~/.claude/skills/`, `~/.claude/commands/`, and `~/.claude/agents/` if they exist. Users must run `bootstrap.sh` after upgrading to clear the duplicates. The plugin is the sole source for these components.
+
+### E3: Plugin cache does not auto-update after new commits (2026-03-09)
+
+`claude plugin install` snapshots files at the install-time git SHA into `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`. After new commits to `system/`, the cache silently serves stale skills, agents, and hooks — no auto-update, no warning. Renames are worst-case: old files persist alongside new ones (e.g., `project-scanner.md` still present after rename to `client-scanner.md`).
+
+**Impact:** Users running installed plugins get outdated behavior indefinitely. Discovered when cache was 40 commits behind HEAD after the t-281 projects→clients rename.
+
+**Workarounds:**
+1. **Dev mode (recommended for contributors):** `claude --plugin-dir ./system` — always reads from HEAD, no cache involved.
+2. **Manual sync:** `rsync -av --delete system/ ~/.claude/plugins/cache/brana/brana/0.7.0/` — must use `--delete` to remove renamed/deleted files.
+3. **Reinstall:** `claude plugin uninstall brana && claude plugin install brana` — re-snapshots from current commit.
+
+**Future fix:** Add a `bootstrap.sh --sync-plugin` flag or post-merge hook that auto-syncs `system/` to the plugin cache when changes are detected.


### PR DESCRIPTION
## Summary
- Document E3 errata in plugin-packaging.md: CC plugin cache drifts silently after new commits
- Add `bootstrap.sh --sync-plugin` flag for quick cache updates via rsync

## Test plan
- [x] `./bootstrap.sh --sync-plugin` detects up-to-date cache
- [x] `./bootstrap.sh --check` unchanged
- [x] `./bootstrap.sh --help` shows new option