### PR TITLE
fix(release): version bump script writes to closed file

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,7 @@
       "changelogFile": "CHANGELOG.md"
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "python3 -c \"\nimport json, sys\nv = '${nextRelease.version}'\nfor path in ['system/.claude-plugin/plugin.json', '.claude-plugin/marketplace.json']:\n    with open(path) as f: d = json.load(f)\n    if 'version' in d: d['version'] = v\n    if 'plugins' in d:\n        for p in d['plugins']: p['version'] = v\n    with open(path, 'w') as f: json.dump(d, f, indent=2)\n    f.write('\\\\n')\nprint(f'Bumped to {v}')\n\""
+      "prepareCmd": "python3 -c \"\nimport json, sys\nv = '${nextRelease.version}'\nfor path in ['system/.claude-plugin/plugin.json', '.claude-plugin/marketplace.json']:\n    with open(path) as f: d = json.load(f)\n    if 'version' in d: d['version'] = v\n    if 'plugins' in d:\n        for p in d['plugins']: p['version'] = v\n    with open(path, 'w') as f:\n        json.dump(d, f, indent=2)\n        f.write('\\\\n')\nprint(f'Bumped to {v}')\n\""
     }],
     ["@semantic-release/git", {
       "assets": [


### PR DESCRIPTION
## Summary
- Fix `ValueError: I/O operation on closed file` in semantic-release version bump
- `f.write('\n')` was outside the `with open` block — moved inside

## Test plan
- [x] Tested locally: `python3 -c "..."` runs without error
- [ ] Release workflow should pass on next merge to main