### PR TITLE
fix(ci): migrate to rulesets + fix release push permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Migrated from legacy branch protection to GitHub rulesets — same rules (require PR, require `validate` check) but with admin bypass so semantic-release can push version commits
- Removed `persist-credentials: false` from release workflow — semantic-release needs GITHUB_TOKEN to push

## What changed (repo settings)
- **Deleted:** Legacy branch protection on `main`
- **Created:** Ruleset `main-protection` with:
  - Require PR (0 approvals — solo repo)
  - Require `validate` status check
  - Bypass: Repository admin role (covers github-actions[bot] for release)

## Test plan
- [ ] PR requires `validate` check to pass (same as before)
- [ ] Release workflow can push version bump commit + tags after merge