### PR TITLE
fix(release): remove plugins that push to protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,10 @@ on:
 
 permissions:
   contents: write
-  issues: write
-  pull-requests: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Only run on main, skip if commit is from semantic-release itself
     if: "!contains(github.event.head_commit.message, 'chore(release):')"
     steps:
       - uses: actions/checkout@v4
@@ -24,13 +21,7 @@ jobs:
           node-version: 20
 
       - name: Install semantic-release
-        run: |
-          npm install -g \
-            semantic-release \
-            @semantic-release/changelog \
-            @semantic-release/git \
-            @semantic-release/github \
-            @semantic-release/exec
+        run: npm install -g semantic-release @semantic-release/github
 
       - name: Release
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,20 +3,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/changelog", {
-      "changelogFile": "CHANGELOG.md"
-    }],
-    ["@semantic-release/exec", {
-      "prepareCmd": "python3 -c \"\nimport json, sys\nv = '${nextRelease.version}'\nfor path in ['system/.claude-plugin/plugin.json', '.claude-plugin/marketplace.json']:\n    with open(path) as f: d = json.load(f)\n    if 'version' in d: d['version'] = v\n    if 'plugins' in d:\n        for p in d['plugins']: p['version'] = v\n    with open(path, 'w') as f:\n        json.dump(d, f, indent=2)\n        f.write('\\\\n')\nprint(f'Bumped to {v}')\n\""
-    }],
-    ["@semantic-release/git", {
-      "assets": [
-        "CHANGELOG.md",
-        "system/.claude-plugin/plugin.json",
-        ".claude-plugin/marketplace.json"
-      ],
-      "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
-    }],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- Remove `@semantic-release/git`, `@semantic-release/changelog`, `@semantic-release/exec` — all require pushing commits to main, which rulesets block for GITHUB_TOKEN
- Keep only `commit-analyzer` + `release-notes-generator` + `github` — creates releases and tags without pushing to the branch
- Slim down permissions (only `contents: write` needed)

## Trade-offs
- No auto-committed CHANGELOG.md — GitHub releases serve as changelog
- No auto-bumped version in plugin.json — explicit version bumps when needed
- Simpler, no Python script, fewer failure modes

## Test plan
- [ ] Release workflow passes after merge
- [ ] GitHub release + tag created automatically